### PR TITLE
demo中注释掉internationalCode字段

### DIFF
--- a/java-sms-demo/src/main/java/com/netease/is/sms/demo/SmsSendDemo.java
+++ b/java-sms-demo/src/main/java/com/netease/is/sms/demo/SmsSendDemo.java
@@ -66,8 +66,8 @@ public class SmsSendDemo {
         map.put("needUp", "false");
         map.put("templateId", templateId);
         map.put("mobile", mobile);
-        //国际短信
-        map.put("internationalCode", "对应的国家编码");
+        // 国际短信对应的国际编码(非国际短信接入请注释掉该行代码)
+        // map.put("internationalCode", "对应的国家编码");
         map.put("params", params);
         map.put("nonce", UUID.randomUUID().toString().replace("-", ""));
         map.put("secretId", SECRETID);

--- a/php-sms-demo/smssend.php
+++ b/php-sms-demo/smssend.php
@@ -85,8 +85,8 @@ function main()
         "templateId" => "xx",
         "mobile" => "xxx",
         "params" => "xx",
-        //国际短信对应的国际区号,不是国际短信不要该值
-        "internationalCode" => "",
+        // 国际短信对应的国际编码(非国际短信接入请注释掉该行代码)
+        // "internationalCode" => "对应的国家编码",
     );
     $ret = check($params);
     var_dump($ret);

--- a/python-sms-demo/smssend.py
+++ b/python-sms-demo/smssend.py
@@ -81,9 +81,9 @@ if __name__ == "__main__":
         "needUp": "false",
         "mobile": "your mobile",
         "templateId": "10084",
-        "params": "p1=xx&p2=xx",
-        # 国际短信对应的国际编码
-        "internationalCode": ""
+        "params": "p1=xx&p2=xx"
+        # 国际短信对应的国际编码(非国际短信接入请注释掉该行代码)
+        # "internationalCode": "对应的国家编码"
     }
     ret = api.send(params)
     if ret is not None:


### PR DESCRIPTION
客户接入时经常出现误传internationalCode字段问题，注释掉该行代码并增加注释说明